### PR TITLE
Update 3.1.4_browser_compatibility.md

### DIFF
--- a/_includes/manuals/nightly/3.1.4_browser_compatibility.md
+++ b/_includes/manuals/nightly/3.1.4_browser_compatibility.md
@@ -3,9 +3,8 @@ Using the most recent version of a major browser is highly recommended, as Forem
 
 The recommended requirements are as follows for major browsers:
 
-* Google Chrome 54 or higher
-* Microsoft Edge
-* Microsoft Internet Explorer 10 or higher
-* Mozilla Firefox 49 or higher
+* Google Chrome latest
+* Microsoft Edge latest
+* Mozilla Firefox latest
 
 Other browsers may work unpredictably.


### PR DESCRIPTION
Since the foreman started using the patternfly-v4 library, it is not compatible with IE anymore.

Also, it requires the latest versions of the supported browsers:
https://www.patternfly.org/v4/get-started/about#supported-browsers